### PR TITLE
ajout stats sur projet du mois arrêts de bus

### DIFF
--- a/bus_stats/bus_stats.factfile
+++ b/bus_stats/bus_stats.factfile
@@ -1,0 +1,63 @@
+{
+    "schema": "iglu:com.snowplowanalytics.factotum/factfile/jsonschema/1-0-0",
+    "data": {
+        "name": "Mise à jour des données de la BATO",
+        "tasks": [
+            {
+                "name": "téléchargement du fichier OSM France",
+                "executor": "shell",
+                "command": "wget 'http://download.geofabrik.de/europe/france-latest.osm.pbf' -O ./work.osm.pbf--no-verbose 2>&1",
+                "arguments": [],
+                "dependsOn": [],
+                "onResult": {
+                    "terminateJobWithSuccess": [ ],
+                    "continueJob": [ 0 ]
+                }
+            },
+            {
+                "name": "filtre OSM sur bus stop",
+                "executor": "shell",
+                "command": "osmosis --read-pbf file='work.osm.pbf' --nkv keyValueList='highway.bus_stop' --write-pbf bus.osm.pbf 2>&1",
+                "arguments": [],
+                "dependsOn": [ "téléchargement du fichier OSM France"],
+                "onResult": {
+                    "terminateJobWithSuccess": [ ],
+                    "continueJob": [ 0 ]
+                }
+            },
+            {
+                "name": "extraction OSM en csv",
+                "executor": "shell",
+                "command": "osmconvert64 bus.osm.pbf --csv='@oname @id @lat @lon name FIXME' --csv-headline --csv-separator=',' -o=bus_stops.csv 2>&1",
+                "arguments": [],
+                "dependsOn": ["filtre OSM sur bus stop"],
+                "onResult": {
+                    "terminateJobWithSuccess": [ ],
+                    "continueJob": [ 0 ]
+                }
+            },
+            {
+                "name": "clean up OSM",
+                "executor": "shell",
+                "command": "rm *.pbf",
+                "arguments": [ ],
+                "dependsOn": ["extraction OSM en csv"],
+                "onResult": {
+                    "terminateJobWithSuccess": [ ],
+                    "continueJob": [ 0 ]
+                }
+            },
+            {
+                "name": "Show Stop Count",
+                "executor": "shell",
+                "command": "cat bus_stops.csv | sed \"1 d\" | wc -l ",
+                "arguments": [ ],
+                "dependsOn": [ "clean up OSM" ],
+                "onResult": {
+                    "terminateJobWithSuccess": [],
+                    "continueJob": [ 0 ]
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Considère que les commandes `osmosis` et `osmconvert64` sont déclarées, soit comme alias soit dans `/user/local/bin`