### PR TITLE
Ref-lignes-stif : petites améliorations UX

### DIFF
--- a/STIF-to-OSM/assets/already_mapped_stop.js
+++ b/STIF-to-OSM/assets/already_mapped_stop.js
@@ -75,16 +75,6 @@ function get_osm_stop_info(stop_id) {
                 bus_stop_content = {};
                 bus_stop_content.name = geo.features[i].properties.tags.name || '<i> pas de nom </i>';
 
-                var ref_STIF_brut = geo.features[i].properties.tags[tag_to_match]
-                if (!ref_STIF_brut) {
-                    alert("Pas d'association opendata pour cet arrêt !")
-                }
-                document.getElementById("osm_ref_match").innerHTML = ref_STIF_brut;
-                bus_stop_content.ref_STIF = ref_STIF_brut.split(";")
-                for (var k = 0; k < bus_stop_content.ref_STIF.length; k++) {
-                    get_navitia_stops_by_ref_id(bus_stop_content.ref_STIF[k])
-                }
-
                 //récupération des parcours desservis d'après OSM
                 relations_bus[bus_stop_id] = [];
                 for (j = 0; j < geo.features[i].properties['relations'].length; j++) {
@@ -112,6 +102,13 @@ function get_osm_stop_info(stop_id) {
                 microcosm_link +=
                     microcosm_link += "' target='_blank'>Explorer la zone</a>"
                 document.getElementById("microcosm_link").innerHTML = microcosm_link
+
+                var ref_STIF_brut = geo.features[i].properties.tags[tag_to_match]
+                document.getElementById("osm_ref_match").innerHTML = ref_STIF_brut || "pas encore de ref:FR:STIF";
+                bus_stop_content.ref_STIF = ref_STIF_brut.split(";")
+                for (var k = 0; k < bus_stop_content.ref_STIF.length; k++) {
+                    get_navitia_stops_by_ref_id(bus_stop_content.ref_STIF[k])
+                }
 
             }
         }

--- a/STIF-to-OSM/assets/bus_lines.js
+++ b/STIF-to-OSM/assets/bus_lines.js
@@ -44,9 +44,10 @@ add_navitia_ref_to_osm.onclick = function() {
             navitia_ref = navitia_lines_data['lines'][selected_navitia_line_index]['codes'][i]['value'];
         }
     }
+    var navitia_line_id = navitia_lines_data['lines'][selected_navitia_line_index]['id']
 
     if (navitia_ref != undefined) {
-        send_navitia_ref_to_openstreetmap(navitia_ref, osm_relation_code, after_osm_modif);
+        send_navitia_ref_to_openstreetmap(navitia_ref, osm_relation_code, navitia_line_id);
     } else {
         console.log("impossible de trouver le code à envoyer à OSM")
     }
@@ -62,7 +63,7 @@ $(document).ready(function() {
 
     get_osm_line_info(osm_relation_code);
     if (line_commercial_code) {
-      get_navitia_lines_candidates(line_commercial_code);
+        get_navitia_lines_candidates(line_commercial_code);
     }
 });
 
@@ -73,17 +74,15 @@ function getParameterByName(name) {
     return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
-function send_navitia_ref_to_openstreetmap(navitia_ref, osm_relation_id, after_osm_modif) {
+function send_navitia_ref_to_openstreetmap(navitia_ref, osm_relation_id, navitia_line_id) {
     var relation_xml = get_node_or_way(osm_relation_id, 'relation'); //mouais, va ptet falloir changer le nom de la fonction dans la lib quand même ...
     edit_tag(relation_xml, 'relation', tag_to_match, navitia_ref)
+
+    function after_osm_modif() {
+        document.location.href = "./route_choose.html?osm_line_id=" + osm_relation_id + "&navitia_line_id=" + navitia_line_id
+    }
     send_data_to_osm(relation_xml, osm_relation_id, "relation", "Ajout de référence opendata STIF sur les lignes", after_osm_modif)
 }
-
-function after_osm_modif(changeset_id, junk) {
-    document.location.href = "https://www.openstreetmap.org/changeset/" + changeset_id
-}
-
-
 
 function get_navitia_lines_candidates(line_code) {
     $.ajax({
@@ -134,7 +133,7 @@ function display_navitia_info(navitia_line_info) {
     document.getElementById("navitia_line_route").innerHTML = navitia_line_info['routes'][0]['name'];
     document.getElementById("navitia_line_mode").innerHTML = navitia_line_info['commercial_mode']['name'];
     document.getElementById("navitia_line_network").innerHTML = navitia_line_info['network']['name'];
-    document.getElementById("navitia_line_color").style = "width:20px;height:20px;background:#" + navitia_line_info['color'] +";";
+    document.getElementById("navitia_line_color").style = "width:20px;height:20px;background:#" + navitia_line_info['color'] + ";";
     //TODO : mettre des liens navitia playground
 }
 
@@ -193,7 +192,7 @@ function get_osm_line_info(relation_id) {
             document.getElementById("osm_line_mode").innerHTML = relation['tags']['route_master'] ? relation['tags']['route_master'] : "<i style='color:red;'>Pas de mode renseigné</i>";
             document.getElementById("osm_line_network").innerHTML = relation['tags']['network'] ? relation['tags']['network'] : "<i style='color:red;'>tag network non renseigné</i>";
             document.getElementById("osm_line_operator").innerHTML = relation['tags']['operator'] ? relation['tags']['operator'] : "<i style='color:red;'>tag operator non renseigné</i>";
-            document.getElementById("osm_line_color").style = "width:20px;height:20px;background:" + relation['tags']['colour'] +";";
+            document.getElementById("osm_line_color").style = "width:20px;height:20px;background:" + relation['tags']['colour'] + ";";
 
             //TODO : mettre des liens OSM
             var is_there_a_match = document.getElementById("osm_ref_match");


### PR DESCRIPTION
* Une fois la ref:FR:STIF ajoutée sur la ligne, l'utilisateur est redirigé vers la page de choix des parcours (et pas osm.org) 
* la page de débug des ref:FR:STIF des arrêts affiche toujours les infos OSM et le lien Microcosm, même s'il n'y a pas encore de ref:FR:STIF sur l'arrêt
* pas d'alert quand l'arrêt n'a pas encore de ref:FR:STIF