### PR TITLE
Toujours appeler JOSM en http

### DIFF
--- a/STIF-to-OSM/assets/stops_by_route.js
+++ b/STIF-to-OSM/assets/stops_by_route.js
@@ -10,7 +10,7 @@ var navitia_route_id = getParameterByName('navitia_route_id');
 //var navitia_route_id = 'route:OIF:014014011:11';
 
 var tag_to_match = "ref:FR:STIF";
-var JOSM_url_base = "https://localhost:8112/load_object?objects="
+var JOSM_url_base = "http://localhost:8111/load_object?objects="
 main()
 
 function find_opendata_closer_stop(osm_stop_pos, opendata_stops) {


### PR DESCRIPTION
Le https dans JOSM n'est pas fiable et sera bientôt abandonné. Voir https://josm.openstreetmap.de/ticket/10033

Tous les navigateurs modernes supportent les requêtes vers 127.0.0.0.1 en http même à partir de pages https, par spécification :

w3c/webappsec-mixed-contenu@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

Le comportement par défaut de JOSM est de fonctionner sans https.

Openstreetmap.org appelle aussi toujours JOSM via http.

Salut à Florian :)